### PR TITLE
Use mavenCentral repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 java {


### PR DESCRIPTION
Stop using jcenter, use Maven Central instead. JCenter has been shutdown and is available only in read-only mode. New packages and versions are no longer added there.

https://blog.gradle.org/jcenter-shutdown
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/