### PR TITLE
fix: Use Time.SYSTEM for initializing system time to compatible with Kafka 3.9

### DIFF
--- a/src/main/java/io/aiven/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/aiven/connect/elasticsearch/ElasticsearchWriter.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -92,7 +92,7 @@ public class ElasticsearchWriter {
         this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
 
         bulkProcessor = new BulkProcessor<>(
-            new SystemTime(),
+            Time.SYSTEM,
             new BulkIndexingClient(client),
             maxBufferedRecords,
             maxInFlightRequests,


### PR DESCRIPTION
Inspired by https://github.com/mongodb/mongo-kafka/pull/171, to make the connect compatible with Kafka 3.9

Kafka removed support for the new SystemTime() instantiation as part of [version 3.9](https://downloads.apache.org/kafka/3.9.0/RELEASE_NOTES.html)

Specifically as part of this [PR](https://github.com/apache/kafka/pull/16266/files).

This change should be safe as far as backwards compatibility goes because that Time.SYSTEM singleton interface [has existed for a long time](https://github.com/dujian0068/kafka/commit/128d0ff91d84a3a1f5a5237133f9ec01caf18d66).