### PR TITLE
fix: Use `Time.SYSTEM` for initializing `SystemTime`

### DIFF
--- a/src/main/java/io/aiven/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/aiven/connect/elasticsearch/ElasticsearchWriter.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -92,7 +92,7 @@ public class ElasticsearchWriter {
         this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
 
         bulkProcessor = new BulkProcessor<>(
-            new SystemTime(),
+            Time.SYSTEM,
             new BulkIndexingClient(client),
             maxBufferedRecords,
             maxInFlightRequests,


### PR DESCRIPTION
The connector fails with `java.lang.IllegalAccessError` in Kafka Connect 3.9, due to SystemTime class exposure change as mentioned by [Kafka 3.9 Release Notes](https://downloads.apache.org/kafka/3.9.0/RELEASE_NOTES.html).

Aiven internal reference: [HH-5830]